### PR TITLE
Added parameterless constructor to WalletExtensionState

### DIFF
--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/Models/WalletExtensionState.cs
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/Models/WalletExtensionState.cs
@@ -69,6 +69,10 @@ namespace CardanoSharp.Blazor.Components.Models
 
 		public int TokenCount { get; set; }
 
+		public WalletExtensionState()
+		{
+		}
+
 		public WalletExtensionState(WalletExtension copy)
 			: base(copy)
 		{


### PR DESCRIPTION
I noticed WalletExtensionState doesn't have a parameterless constructor and this blocks a lot of stuff, so I added it :) Maybe it can be merged together with other more important stuff.