### PR TITLE
GetUtxo AssetName in Hex fix

### DIFF
--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/CardanoSharp.Blazor.Components.csproj
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/CardanoSharp.Blazor.Components.csproj
@@ -12,7 +12,7 @@
     <Authors>CardanoSharp</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>3.2.2</Version>
+    <Version>3.3.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="Blazored.LocalStorage" Version="4.3.0" />
-    <PackageReference Include="CardanoSharp.Wallet" Version="4.0.2" />
+    <PackageReference Include="CardanoSharp.Wallet" Version="4.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="6.0.4" />
   </ItemGroup>
 

--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.TestApp/Server/CardanoSharp.Blazor.TestApp.Server.csproj
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.TestApp/Server/CardanoSharp.Blazor.TestApp.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CardanoSharp.Wallet" Version="4.0.2" />
+    <PackageReference Include="CardanoSharp.Wallet" Version="4.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.4" />
   </ItemGroup>
 


### PR DESCRIPTION
Could be breaking change, but currently the way the older ver of the wallet library was deserializing to utxo is not to spec, it was doing UTF-8 conversion, but AssetName should always be in Hex format as per Mary era spec, as it can contain non-readable characters.