### PR TITLE
Added parameter to allow user to specify the placement of the wallet name

### DIFF
--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/CardanoSharp.Blazor.Components.csproj
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/CardanoSharp.Blazor.Components.csproj
@@ -11,8 +11,8 @@
     <Description>CardanoSharp.Blazor.Components is a component library for C# devs to easily get started with developing dApps for Cardano.</Description>
     <Authors>CardanoSharp</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression
-    <Version>8.0.0</Version
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Version>8.0.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/CardanoSharp.Blazor.Components.csproj
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/CardanoSharp.Blazor.Components.csproj
@@ -12,7 +12,7 @@
     <Authors>CardanoSharp</Authors>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>3.3.10</Version>
+    <Version>3.3.11</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/Enums/WalletConnectorNamePlacements.cs
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/Enums/WalletConnectorNamePlacements.cs
@@ -1,0 +1,8 @@
+﻿namespace CardanoSharp.Blazor.Components.Enums;
+
+public enum WalletConnectorNamePlacements
+{
+    NotSet = 0,
+    AboveWalletCard = 1,
+    BelowWalletCard = 2
+}

--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/WalletConnector.razor
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/WalletConnector.razor
@@ -129,8 +129,15 @@ else
                                             @foreach (var extension in _wallets)
                                             {
                                                 <div class="wallet-card">
-                                                    <span class="wallet-card-title">@extension.Name Wallet</span>
+                                                    @if (WalletConnectorNamePlacement == WalletConnectorNamePlacements.AboveWalletCard)
+                                                    {
+                                                        <span class="wallet-card-title">@extension.Name</span>
+                                                    }                                                    
                                                     <img class="wallet-card-icon" src="@extension.Icon" title="@extension.Name"/>
+                                                    @if (WalletConnectorNamePlacement == WalletConnectorNamePlacements.BelowWalletCard)
+                                                    {
+                                                        <span class="wallet-card-title">@extension.Name</span>
+                                                    }
                                                     @if (extension.Installed && extension.Connected)
                                                     {
                                                         <button class="wallet-button" @onclick="@(async () => await DisconnectWalletAsync())">@DisconnectButtonText</button>

--- a/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/WalletConnector.razor.cs
+++ b/CardanoSharp.Blazor/CardanoSharp.Blazor.Components/WalletConnector.razor.cs
@@ -113,6 +113,9 @@ public partial class WalletConnector
     [Parameter]
     public RenderFragment<WalletsModalContentViewModel> WalletsModalContent { get; set; } = null!;
 
+    [Parameter]
+    public WalletConnectorNamePlacements WalletConnectorNamePlacement { get; set; } = WalletConnectorNamePlacements.AboveWalletCard;
+
     public WalletExtensionState? ConnectedWallet { get; private set; }
 
     public bool PopupDialogShowing { get; private set; }


### PR DESCRIPTION
User can now specify the wallet label placement.

As per default it will be above the wallet card, but the user now has the option to display it below the wallet card